### PR TITLE
Update Crypto++ version to 6.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if (NOT CMAKE_CONFIGURATION_TYPES AND
 endif ()
 
 set(cryptopp_VERSION_MAJOR 6)
-set(cryptopp_VERSION_MINOR 0)
+set(cryptopp_VERSION_MINOR 1)
 set(cryptopp_VERSION_PATCH 0)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
Hello,
since [Crypto++ 6.1.0](https://github.com/weidai11/cryptopp/releases/tag/CRYPTOPP_6_1_0) was released almost a month ago, the version number in `CMakeLists.txt` should probably be updated.