### PR TITLE
GAS_STRING contains on Windows multiple tokens separated by spaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,7 +270,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 		execute_process(COMMAND ${GAS_CMD}
 			OUTPUT_VARIABLE GAS_STRING
 			OUTPUT_STRIP_TRAILING_WHITESPACE)
-		string(FIND ${GAS_STRING} "GNU assembler" GAS_OUTPUT)
+		string(FIND "${GAS_STRING}" "GNU assembler" GAS_OUTPUT)
 
 		if (NOT GAS_OUTPUT EQUAL -1)
 			#.intel_syntax wasn't supported until GNU assembler 2.10


### PR DESCRIPTION
Tokens, separated with spaces will be handled as additional parameters ending up in too many parameter error for string command.