### PR TITLE
Enable ASM_MASM instead of ASM on MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,11 +483,8 @@ if (MSVC AND NOT DISABLE_ASM)
     else ()
       set_source_files_properties(${cryptopp_SOURCES_ASM} PROPERTIES COMPILE_DEFINITIONS "_M_X86" COMPILE_FLAGS "/safeseh")
     endif ()
+    set_source_files_properties(${cryptopp_SOURCES_ASM} PROPERTIES LANGUAGE ASM_MASM)
   endif ()
-endif ()
-
-if (cryptopp_SOURCES_ASM)
-  set_source_files_properties(${cryptopp_SOURCES_ASM} PROPERTIES LANGUAGE ASM)
 endif ()
 
 #============================================================================


### PR DESCRIPTION
Without this change rdrand.asm, x64dll.asm and x64masm.asm do not participate in build.