### PR TITLE
Fix travis ci build file to let travis clone cryptopp-cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,11 @@ before_script:
   # cp "$PWD/cmake/cryptopp-config.cmake" "$PWD"
   # cp "$PWD/cmake/CMakeLists.txt" "$PWD"
   - |
+    cd ..
     git clone --branch CRYPTOPP_7_0_0 https://github.com/weidai11/cryptopp.git
+    cp cryptopp-cmake/cryptopp-config.cmake cryptopp
+    cp cryptopp-cmake/CMakeLists.txt cryptopp
     cd cryptopp
-    git submodule add https://github.com/noloader/cryptopp-cmake.git cmake
-    git submodule update --remote
-    cp cmake/cryptopp-config.cmake .
-    cp cmake/CMakeLists.txt .
 
   #
   # Build Folder
@@ -105,18 +104,17 @@ matrix:
       # Workflow as per the README.md to setup the cryptopp sources
       #
       - |
+        cd ..
+        mkdir test
+        cd test
         git clone --branch CRYPTOPP_7_0_0 https://github.com/weidai11/cryptopp.git
-        cd cryptopp
-        git submodule add https://github.com/noloader/cryptopp-cmake.git cmake
-        git submodule update --remote
-        cp cmake/cryptopp-config.cmake .
-        cp cmake/CMakeLists.txt .
+        cp ../cryptopp-cmake/cryptopp-config.cmake cryptopp
+        cp ../cryptopp-cmake/CMakeLists.txt cryptopp
 
       #
       # Call it from a project that requires recent version of cmake
       #
       - |
-        cd ..
         echo "cmake_minimum_required(VERSION 3.10)" > CMakeLists.txt
         echo "# This next line is the one that will trigger CMP0048 new behavior" >> CMakeLists.txt
         echo "project(abc VERSION 1.0.0)" >> CMakeLists.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,13 @@ git:
 # Build Dependencies
 #
 before_script:
-  # Test the workflow as per the README.md
+  # Test the build workflow slightly differenly from the README.md
   #
-  # git clone https://github.com/weidai11/cryptopp.git
-  # cd cryptopp
-  # git submodule add https://github.com/noloader/cryptopp-cmake.git cmake
-  # git submodule update --remote
+  # Let travis clone cryptopp-cmake
+  # cd ..
+  # git clone --branch CRYPTOPP_7_0_0 https://github.com/weidai11/cryptopp.git
   #
-  # cp "$PWD/cmake/cryptopp-config.cmake" "$PWD"
-  # cp "$PWD/cmake/CMakeLists.txt" "$PWD"
+  # Copy cmake files to cryptopp then build
   - |
     cd ..
     git clone --branch CRYPTOPP_7_0_0 https://github.com/weidai11/cryptopp.git
@@ -101,7 +99,15 @@ matrix:
         fi
 
       #
-      # Workflow as per the README.md to setup the cryptopp sources
+      # Test the build workflow slightly differenly from the README.md
+      #
+      # Let travis clone cryptopp-cmake
+      # cd ..
+      # Create a parent test project
+      # git clone --branch CRYPTOPP_7_0_0 https://github.com/weidai11/cryptopp.git
+      # Copy cmake files to cryptopp then build
+      # Create cmake file for the test project on the fly
+      # Build test project and cryptopp as a subdirectory
       #
       - |
         cd ..


### PR DESCRIPTION
The build workflow in README.md is not suitable for CI. It does not allow the CI to test the changes from pull requests and branches. 

Build file changed to let travis clone cryptopp-cmake and then we manually setup cryptopp and the test project and copy the cmake files from the cryptopp-cmake.