### PR TITLE
winapifamily.h fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,8 +388,9 @@ endif ()
 if (MSVC)
   if (CMAKE_SYSTEM_VERSION MATCHES "10\\.0.*")
     list(APPEND CRYPTOPP_COMPILE_DEFINITIONS "_WIN32_WINNT=0x0A00")
+  else ()
+    list(APPEND CRYPTOPP_COMPILE_OPTIONS "/FI\"winapifamily.h\"")
   endif ()
-  list(APPEND CRYPTOPP_COMPILE_OPTIONS "/FI\"winapifamily.h\"")
 endif ()
 
 # Enable PIC for all target machines except 32-bit i386 due to register pressures.


### PR DESCRIPTION
For some reason this file is being force-included into windows builds and causes plenty of `'"winapifamily.h"': No such file or directory` errors while building. Commenting the line seems to solve the issue for me(Visual studio 2017 Enterprise).

Though with my shallow understanding of how Windows SDKs are organized, I think you meant to do this:
```
if (MSVC)
  if (CMAKE_SYSTEM_VERSION MATCHES "10\\.0.*")
    list(APPEND CRYPTOPP_COMPILE_DEFINITIONS "_WIN32_WINNT=0x0A00")
  else ()
    list(APPEND CRYPTOPP_COMPILE_OPTIONS "/FI\"winapifamily.h\"")
  endif ()
endif ()
```
As the newer Windows 10 SDKs don't have `winapifamily.h`, but the older Windows 8-and-below sdks have `winapifamily.h` in their `shared` directory. I think SDL ran into a similar issue with the newer SDKs.