### PR TITLE
Handle Android NDK standalone toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,7 +299,7 @@ DumpMachine(CRYPTOPP_X32 "x32")
 DumpMachine(CRYPTOPP_AARCH32 "Aarch32")
 DumpMachine(CRYPTOPP_AARCH64 "Aarch64")
 DumpMachine(CRYPTOPP_ARMHF "armhf|arm7l|eabihf")
-DumpMachine(CRYPTOPP_ARM "\\<arm\\>")
+DumpMachine(CRYPTOPP_ARM "\\<arm\\>|armv")
 
 # Detecting PowerPC is only good with GCC. IBM XLC compiler is
 # a little different and I don't know how to ask to the triplet


### PR DESCRIPTION
For Android NDK Standalone toolchain `-dumpmachine` returns:

```
arm-linux-androideabi-clang++ -dumpmachine
armv7a-none-linux-android16
```

> This toolchain created with `$ANDROID_NDK_ROOT/build/tools/make_standalone_toolchain.py --arch arm --api 16 --install-dir /opt/arm-16-toolchain`

After applying this PR compilation works locally (via Conan) I'm not very familiar with Crypto++ so I need help with review/suggestion (maybe there is better way to achieve my needs)