### PR TITLE
Add cryptopp as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cryptopp"]
+	path = cryptopp
+	url = https://github.com/weidai11/cryptopp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,11 @@ else ()
 endif ()
 
 # Need to set SRC_DIR manually after removing the Python library code.
-set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/cryptopp)
+  set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cryptopp CACHE PATH "Path to cryptopp")
+else ()
+  set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE PATH "Path to cryptopp")
+endif()
 
 # Make RelWithDebInfo the default (it does e.g. add '-O2 -g -DNDEBUG' for GNU)
 #   If not in multi-configuration environments, no explicit build type or CXX

--- a/README.md
+++ b/README.md
@@ -26,15 +26,14 @@ If you want to use `cryptest-cmake.sh` to drive things then perform the followin
 
 ## Workflow
 
-The general workflow is clone Wei Dai's crypto++, add CMake as a submodule, and then copy the files of interest into the Crypto++ directory:
+The general workflow is clone this repo, and build with cmake:
 
-    git clone https://github.com/weidai11/cryptopp.git
-    cd cryptopp
-
-    wget -O CMakeLists.txt https://raw.githubusercontent.com/noloader/cryptopp-cmake/master/CMakeLists.txt
-    wget -O cryptopp-config.cmake https://raw.githubusercontent.com/noloader/cryptopp-cmake/master/cryptopp-config.cmake
-
-Despite our efforts we have not been able to add the submodule to Crypto++ for seamless integration. If anyone knows how to add the submodule directly to the Crypto++ directory, then please provide the instructions.
+    git clone --recurse-submodules https://github.com/noloader/cryptopp-cmake.git
+    cd cryptopp-cmake
+    mkdir build
+    cd build
+    cmake ..
+    cmake --build .
 
 ## ZIP Files
 


### PR DESCRIPTION
There's a comment in the readme about not being able to add this as a submodule to cryptopp, but why not do it the other way around? It makes it easier to use, e.g. as a submodule in other projects. It also means that each commit in this repo is tied to a specific commit in cryptopp that it can build correctly, so when files are moved around it doesn't cause problems.