### PR TITLE
Add a USE_OPENMP flag to enable building with OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,11 @@ option(BUILD_TESTING "Build library tests" ON)
 option(BUILD_DOCUMENTATION "Use Doxygen to create the HTML based API documentation" OFF)
 option(USE_INTERMEDIATE_OBJECTS_TARGET "Use a common intermediate objects target for the static and shared library targets" ON)
 
+if (${CMAKE_VERSION} VERSION_GREATER "3.1")
+  option(USE_OPENMP "Enable OpenMP to parallelize some of the algorithms. Note that this isn't always faster, see https://www.cryptopp.com/wiki/OpenMP" OFF)
+endif()
+
+
 # These are IA-32 options.
 option(DISABLE_ASM "Disable ASM" OFF)
 option(DISABLE_SSSE3 "Disable SSSE3" OFF)
@@ -1114,6 +1119,80 @@ endif ()
 if (BUILD_SHARED)
   target_link_libraries(cryptopp-shared ${CMAKE_THREAD_LIBS_INIT})
 endif ()
+
+
+#============================================================================
+# Setup OpenMP
+#============================================================================
+if (${CMAKE_VERSION} VERSION_GREATER "3.1" AND USE_OPENMP)
+  find_package(OpenMP)
+
+  if (OPENMP_FOUND OR OPENMP_CXX_FOUND)
+      message(STATUS "OpenMP: Found libomp without any special flags")
+  endif()
+
+  # If OpenMP wasn't found, try if we can find it in the default Macports location
+  if((NOT OPENMP_FOUND) AND (NOT OPENMP_CXX_FOUND) AND EXISTS "/opt/local/lib/libomp/libomp.dylib") # older cmake uses OPENMP_FOUND, newer cmake also sets OPENMP_CXX_FOUND, homebrew installations seem only to get the latter set.
+      set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I/opt/local/include/libomp/")
+      set(OpenMP_CXX_LIB_NAMES omp)
+      set(OpenMP_omp_LIBRARY /opt/local/lib/libomp/libomp.dylib)
+
+      find_package(OpenMP)
+      if (OPENMP_FOUND OR OPENMP_CXX_FOUND)
+          message(STATUS "OpenMP: Found libomp in macports default location.")
+      else()
+          message(FATAL_ERROR "OpenMP: Didn't find libomp. Tried macports default location but also didn't find it.")
+      endif()
+  endif()
+
+  # If OpenMP wasn't found, try if we can find it in the default Homebrew location
+  if((NOT OPENMP_FOUND) AND (NOT OPENMP_CXX_FOUND) AND EXISTS "/usr/local/opt/libomp/lib/libomp.dylib")
+      set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I/usr/local/opt/libomp/include")
+      set(OpenMP_CXX_LIB_NAMES omp)
+      set(OpenMP_omp_LIBRARY /usr/local/opt/libomp/lib/libomp.dylib)
+
+      find_package(OpenMP)
+      if (OPENMP_FOUND OR OPENMP_CXX_FOUND)
+          message(STATUS "OpenMP: Found libomp in homebrew default location.")
+      else()
+          message(FATAL_ERROR "OpenMP: Didn't find libomp. Tried homebrew default location but also didn't find it.")
+      endif()
+  endif()
+
+  set(Additional_OpenMP_Libraries_Workaround "")
+
+  # Workaround because older cmake on apple doesn't support FindOpenMP
+  if((NOT OPENMP_FOUND) AND (NOT OPENMP_CXX_FOUND))
+      if((APPLE AND ((CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")))
+              AND ((CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "7.0") AND (CMAKE_VERSION VERSION_LESS "3.12.0")))
+          message(STATUS "OpenMP: Applying workaround for OSX OpenMP with old cmake that doesn't have FindOpenMP")
+          set(OpenMP_CXX_FLAGS "-Xclang -fopenmp")
+          set(Additional_OpenMP_Libraries_Workaround "-lomp")
+      else()
+          message(FATAL_ERROR "OpenMP: Did not find OpenMP. Build without USE_OPENMP if you want to allow this.")
+      endif()
+  endif()
+
+  if(NOT TARGET OpenMP::OpenMP_CXX)
+      # We're on cmake < 3.9, handle behavior of the old FindOpenMP implementation
+      message(STATUS "OpenMP: Applying workaround for old CMake that doesn't define FindOpenMP using targets")
+      add_library(OpenMP_TARGET INTERFACE)
+      add_library(OpenMP::OpenMP_CXX ALIAS OpenMP_TARGET)
+      target_compile_options(OpenMP_TARGET INTERFACE ${OpenMP_CXX_FLAGS}) # add to all targets depending on this
+      find_package(Threads REQUIRED)
+      target_link_libraries(OpenMP_TARGET INTERFACE Threads::Threads)
+      target_link_libraries(OpenMP_TARGET INTERFACE ${OpenMP_CXX_FLAGS} ${Additional_OpenMP_Libraries_Workaround})
+  endif()
+
+  if (BUILD_STATIC)
+    target_link_libraries(cryptopp-static ${OpenMP_CXX_FLAGS}) # Workaround for Ubuntu 18.04 that otherwise doesn't set -fopenmp for linking
+    target_link_libraries(cryptopp-static OpenMP::OpenMP_CXX)
+  endif()
+  if (BUILD_SHARED)
+    target_link_libraries(cryptopp-shared ${OpenMP_CXX_FLAGS}) # Workaround for Ubuntu 18.04 that otherwise doesn't set -fopenmp for linking
+    target_link_libraries(cryptopp-shared OpenMP::OpenMP_CXX)
+  endif()
+endif()
 
 #============================================================================
 # Tests


### PR DESCRIPTION
Fixes https://github.com/noloader/cryptopp-cmake/issues/68

I wasn't able to implement it for CMake before 3.1, but I feature gated it. Builds with older cmake versions should still work just fine, they just won't have the flag.