### PR TITLE
Fix compiler options setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1037,10 +1037,10 @@ endif ()
 # add_compile_definitions added in CMake 3.12
 if (${CMAKE_VERSION} VERSION_LESS "3.12")
   # https://stackoverflow.com/q/61250087
-  add_definitions("${CMAKE_CPP_FLAGS}" "${CMAKE_CXX_FLAGS}" "${CRYPTOPP_COMPILE_DEFINITIONS}" "${CRYPTOPP_COMPILE_OPTIONS}")
+  add_definitions(${CMAKE_CPP_FLAGS} ${CRYPTOPP_COMPILE_DEFINITIONS} ${CRYPTOPP_COMPILE_OPTIONS})
 else()
-  add_compile_definitions("${CMAKE_CPP_FLAGS}" "${CRYPTOPP_COMPILE_DEFINITIONS}")
-  add_compile_options("${CMAKE_CXX_FLAGS}" "${CRYPTOPP_COMPILE_OPTIONS}")
+  add_compile_definitions(${CRYPTOPP_COMPILE_DEFINITIONS})
+  add_compile_options(${CMAKE_CPP_FLAGS} ${CRYPTOPP_COMPILE_OPTIONS})
 endif()
 
 #============================================================================


### PR DESCRIPTION
 - quotes should not be used, they break multiple options support
 - cmake already using CMAKE_CXX_FLAGS, no need to add them again
 - CMAKE_CPP_FLAGS belong to options and not definitions