### PR TITLE
dont double-add CRYPTOPP_COMPILE_DEFINITIONS 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1045,7 +1045,7 @@ if (${CMAKE_VERSION} VERSION_LESS "3.12")
 else()
   # Fucking CMake blows. It does not honor add_compile_definitions.
   add_compile_definitions(${CMAKE_CPP_FLAGS} ${CRYPTOPP_COMPILE_DEFINITIONS})
-  add_compile_options(${CMAKE_CXX_FLAGS} ${CRYPTOPP_COMPILE_DEFINITIONS} ${CRYPTOPP_COMPILE_OPTIONS})
+  add_compile_options(${CMAKE_CXX_FLAGS} ${CRYPTOPP_COMPILE_OPTIONS})
 endif()
 
 #============================================================================


### PR DESCRIPTION
Otherwise, if you run
`cmake -D DISABLE_ASM=ON . && make VERBOSE=1`
you will get a compiler invocation like
/usr/bin/c++  **-DCRYPTOPP_DISABLE_ASM**  -O2 -g -DNDEBUG -fPIC   **CRYPTOPP_DISABLE_ASM** -o CMakeFiles/cryptopp-object.dir/cryptlib.cpp.o -c /path/cryptopp/cryptlib.cpp

with "c++: error: CRYPTOPP_DISABLE_ASM" file not found (it is twice in the command line options, once with -D and once without it).

This should fix it.